### PR TITLE
Do not let user request gas when city is inputted

### DIFF
--- a/src/app/controller/Main.coffee
+++ b/src/app/controller/Main.coffee
@@ -354,7 +354,7 @@ Ext.define 'Purple.controller.Main',
     @updateDeliveryLocAddressByLatLng @deliveryLocLat, @deliveryLocLng
 
   updateMapWithAddressComponents: (address) ->
-    zipCodeUpdated = false
+    @deliveryAddressZipCode = null
     if address[0]?['address_components']?
       addressComponents = address[0]['address_components']
       streetAddress = "#{addressComponents[0]['short_name']} #{addressComponents[1]['short_name']}"
@@ -363,7 +363,6 @@ Ext.define 'Purple.controller.Main',
       for c in addressComponents
         for t in c.types
           if t is "postal_code"
-            zipCodeUpdated = true
             @deliveryAddressZipCode = c['short_name']
             if not localStorage['gps_not_allowed_event_sent'] and not localStorage['first_launch_loc_sent']?
               # this means that this is the zip code of the location
@@ -372,8 +371,6 @@ Ext.define 'Purple.controller.Main',
                 street_address: streetAddress
                 zip_code: @deliveryAddressZipCode
               localStorage['first_launch_loc_sent'] = 'yes'
-      if not zipCodeUpdated
-        @deliveryAddressZipCode = null
       @busyGettingGasPrice ?= no
       if not @busyGettingGasPrice
         @busyGettingGasPrice = yes
@@ -410,7 +407,8 @@ Ext.define 'Purple.controller.Main',
             @busyGettingGasPrice = no
           failure: (response_obj) ->
             @busyGettingGasPrice = no
-            console.log response_obj
+            if not @deliveryAddressZipCode
+              @adjustDeliveryLocByLatLng()
 
   updateDeliveryLocAddressByLatLng: (lat, lng) ->
     if @bypassUpdateDeliveryLocAddressByLatLng? and @bypassUpdateDeliveryLocAddressByLatLng


### PR DESCRIPTION
This makes it so that when a user inputs a city address, it won't have the wrong zip code attached to it. Instead, it will be set to null. The user will not be able to request gas and the gas price area will say that they are not in a valid service area, forcing the user to enter another location.
