### PR TITLE
Fix for select field and check box field focus on label click

### DIFF
--- a/src/override/Field.coffee
+++ b/src/override/Field.coffee
@@ -3,5 +3,6 @@ Ext.define 'Override.field.Field',
 
   initialize: (field) ->
     @callParent()
-    @element.on 'tap', => 
-      @focus()
+    for child in [0...@element.dom.children.length]
+      if @element.dom.children[child].className is "x-form-label"
+        @element.dom.children[child].onclick = (=> @focus?())


### PR DESCRIPTION
This seems to be a solution. Checking the children of the field elements, and if there is a label, then we are setting it to focus the element when clicked. Tested and no longer throws errors on select and checkbox fields.
